### PR TITLE
stricter types, throws error if from > to, devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,23 @@
+// See https://github.com/julia-vscode/julia-devcontainer/blob/master/Dockerfile for image contents
+{
+	"name": "Julia (Community)",
+	"image": "ghcr.io/julia-vscode/julia-devcontainer",
+
+	// Configure tool-specific properties.
+	"customizations": {
+		// Configure properties specific to VS Code.
+		"vscode": {
+			// Add the IDs of extensions you want installed when the container is created.
+			"extensions": [
+				"julialang.language-julia"
+			]
+		}
+	},
+
+	"postCreateCommand": "/julia-devcontainer-scripts/postcreate.jl",
+
+	"remoteUser": "vscode",
+	"features": {
+		"ghcr.io/meaningful-ooo/devcontainer-features/fish:1": {}
+	}
+}

--- a/src/ExperienceAnalysis.jl
+++ b/src/ExperienceAnalysis.jl
@@ -6,23 +6,23 @@ export exposure
 
 abstract type ExposurePeriod end
 
-struct Anniversary{T} <: ExposurePeriod
-    pol_period::T
+struct Anniversary <: ExposurePeriod
+    pol_period::Union{Month, Year}
 end
 
-struct AnniversaryCalendar{T,U} <: ExposurePeriod
-    pol_period::T
-    cal_period::U
+struct AnniversaryCalendar <: ExposurePeriod
+    pol_period::Union{Month, Year}
+    cal_period::Union{Month, Year}
 end
 
-struct Calendar{U} <: ExposurePeriod
-    cal_period::U
+struct Calendar <: ExposurePeriod
+    cal_period::Union{Month, Year}
 end
 
 # make ExposurePeriod broadcastable so that you can broadcast 
 Base.Broadcast.broadcastable(ic::ExposurePeriod) = Ref(ic)
 
-function next_exposure(from, to, period)
+function next_exposure(from::Date, to::Date, period::Union{Month, Year})
     return (from=from, to=min(from + period, to))
 end
 
@@ -52,7 +52,8 @@ julia> exposure(basis, issue, termination)
 
 
 """
-function exposure(p::Anniversary{T}, from, to, continued_exposure=false) where {T}
+function exposure(p::Anniversary, from::Date, to::Date, continued_exposure::Bool=false)
+    to < from && throw(DomainError("from=$from argument is a later date than the to=$to argument."))
     period = p.pol_period
     result = [next_exposure(from, to, period)]
     while result[end].to < to
@@ -69,8 +70,8 @@ function exposure(p::Anniversary{T}, from, to, continued_exposure=false) where {
     return result
 end
 
-function exposure(p::AnniversaryCalendar{T,U}, from, to, continued_exposure=false) where {T,U}
-
+function exposure(p::AnniversaryCalendar, from::Date, to::Date, continued_exposure::Bool=false)
+    to < from && throw(DomainError("from=$from argument is a later date than the to=$to argument."))
     period = min(p.cal_period, p.pol_period)
 
     next_pol_per = from + p.pol_period
@@ -103,7 +104,8 @@ function exposure(p::AnniversaryCalendar{T,U}, from, to, continued_exposure=fals
     return result
 end
 
-function exposure(p::Calendar{U}, from, to, continued_exposure=false) where {U}
+function exposure(p::Calendar, from::Date, to::Date, continued_exposure::Bool=false)
+    to < from && throw(DomainError("from=$from argument is a later date than the to=$to argument."))
     period = p.cal_period
 
     next_cal_per = ceil(from, p.cal_period)

--- a/src/ExperienceAnalysis.jl
+++ b/src/ExperienceAnalysis.jl
@@ -6,17 +6,17 @@ export exposure
 
 abstract type ExposurePeriod end
 
-struct Anniversary <: ExposurePeriod
-    pol_period::Period
+struct Anniversary{T<:Period} <: ExposurePeriod
+    pol_period::T
 end
 
-struct AnniversaryCalendar <: ExposurePeriod
-    pol_period::Period
-    cal_period::Period
+struct AnniversaryCalendar{T<:Period, U<:Period} <: ExposurePeriod
+    pol_period::T
+    cal_period::U
 end
 
-struct Calendar <: ExposurePeriod
-    cal_period::Period
+struct Calendar{U<:Period} <: ExposurePeriod
+    cal_period::U
 end
 
 # make ExposurePeriod broadcastable so that you can broadcast 

--- a/src/ExperienceAnalysis.jl
+++ b/src/ExperienceAnalysis.jl
@@ -7,22 +7,22 @@ export exposure
 abstract type ExposurePeriod end
 
 struct Anniversary <: ExposurePeriod
-    pol_period::Union{Month, Year}
+    pol_period::Period
 end
 
 struct AnniversaryCalendar <: ExposurePeriod
-    pol_period::Union{Month, Year}
-    cal_period::Union{Month, Year}
+    pol_period::Period
+    cal_period::Period
 end
 
 struct Calendar <: ExposurePeriod
-    cal_period::Union{Month, Year}
+    cal_period::Period
 end
 
 # make ExposurePeriod broadcastable so that you can broadcast 
 Base.Broadcast.broadcastable(ic::ExposurePeriod) = Ref(ic)
 
-function next_exposure(from::Date, to::Date, period::Union{Month, Year})
+function next_exposure(from::Date, to::Date, period::Period)
     return (from=from, to=min(from + period, to))
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,11 +14,11 @@ using Dates
     end
 
     @testset "Year with full exp" begin
-    exp = exposure(ExperienceAnalysis.Anniversary(Year(1)), issue, termination,true)
+        exp = exposure(ExperienceAnalysis.Anniversary(Year(1)), issue, termination,true)
 
-    @test exp[1]   == (from = Date(2016, 7, 4), to = Date(2017, 7, 4))
-    @test exp[end] == (from = Date(2019, 7, 4), to = Date(2020, 7, 4))
-end
+        @test exp[1]   == (from = Date(2016, 7, 4), to = Date(2017, 7, 4))
+        @test exp[end] == (from = Date(2019, 7, 4), to = Date(2020, 7, 4))
+    end
 
     @testset "Month" begin
         exp = exposure(ExperienceAnalysis.Anniversary(Month(1)), issue, termination)
@@ -41,12 +41,12 @@ end
     end
 
     @testset "Year with full exp" begin
-    exp = exposure(ExperienceAnalysis.Calendar(Year(1)), issue, termination,true)
+        exp = exposure(ExperienceAnalysis.Calendar(Year(1)), issue, termination,true)
 
-    @test exp[1]   == (from = Date(2016, 7, 4), to = Date(2017, 1, 1))
-    @test exp[2]   == (from = Date(2017, 1, 1), to = Date(2018, 1, 1))
-    @test exp[end] == (from = Date(2020, 1, 1), to = Date(2021, 1, 1))
-end
+        @test exp[1]   == (from = Date(2016, 7, 4), to = Date(2017, 1, 1))
+        @test exp[2]   == (from = Date(2017, 1, 1), to = Date(2018, 1, 1))
+        @test exp[end] == (from = Date(2020, 1, 1), to = Date(2021, 1, 1))
+    end
 
     @testset "Month" begin
         exp = exposure(ExperienceAnalysis.Calendar(Month(1)), issue, termination)
@@ -71,12 +71,12 @@ end
     end
 
     @testset "Year/Year with full exp" begin
-    exp = exposure(ExperienceAnalysis.AnniversaryCalendar(Year(1), Year(1)), issue, termination,true)
+        exp = exposure(ExperienceAnalysis.AnniversaryCalendar(Year(1), Year(1)), issue, termination,true)
 
-    @test exp[1]   == (from = Date(2016, 7, 4), to = Date(2017, 1, 1))
-    @test exp[2]   == (from = Date(2017, 1, 1), to = Date(2017, 7, 4))
-    @test exp[end] == (from = Date(2020, 1, 1), to = Date(2020, 7, 4))
-end
+        @test exp[1]   == (from = Date(2016, 7, 4), to = Date(2017, 1, 1))
+        @test exp[2]   == (from = Date(2017, 1, 1), to = Date(2017, 7, 4))
+        @test exp[end] == (from = Date(2020, 1, 1), to = Date(2020, 7, 4))
+    end
 
 
     @testset "Month/Year" begin
@@ -95,6 +95,12 @@ end
         @test exp[2]   == (from = Date(2016, 8, 1), to = Date(2016, 8, 4))
         @test exp[end] == (from = Date(2020, 1, 4), to = Date(2020, 1, 17))
     end
+end
+
+@testset "from > to throws error" begin
+    @test_throws DomainError exposure(ExperienceAnalysis.Anniversary(Year(1)), Date(2020, 1, 17), Date(2016, 7, 4))
+    @test_throws DomainError exposure(ExperienceAnalysis.AnniversaryCalendar(Year(1), Year(1)), Date(2020, 1, 17), Date(2016, 7, 4))
+    @test_throws DomainError exposure(ExperienceAnalysis.Calendar(Year(1)), Date(2020, 1, 17), Date(2016, 7, 4))
 end
 
 


### PR DESCRIPTION
* There were some parametric types which are now `Union{Month, Year}` #6 
* If `from>to` there is now an error that is thrown, tests are added for this behavior. #10 
* Config files for a devcontainer are added, I believe codespaces are now generally available